### PR TITLE
Added support for GitHub Enterprise.

### DIFF
--- a/lib/github-service.coffee
+++ b/lib/github-service.coffee
@@ -3,13 +3,15 @@ gitup = require 'git-up'
 
 module.exports =
 class GithubService
-  # #DONE:0 Put github in a github helper issue:3
-  github: new GitHubApi
-      version: "3.0.0"
-      headers:
-        "user-agent": "imdone-atom"
   constructor: (@model) ->
     @model.service = this
+    # #DONE:0 Put github in a github helper issue:3
+    @github = new GitHubApi
+        version: "3.0.0"
+        host: @model.hostname
+        pathPrefix: @model.path
+        headers:
+          "user-agent": "imdone-atom"
 
   getGithubRepo: (cb) ->
     dirs = (dir for dir in atom.project.getDirectories() when dir.path == @model.repo.path)
@@ -24,7 +26,7 @@ class GithubService
         target = gitRepo.getReferenceTarget(upstream)
         console.log "*** Found upstream branch: %s with target: %s ***", upstream, target
       parsedURL = gitup originURL
-      @model.githubRepoUrl = originURL if parsedURL.resource == 'github.com'
+      @model.githubRepoUrl = originURL if parsedURL.resource == @model.resourceName
       if @model.githubRepoUrl
         parts = parsedURL.pathname.split '/'
         @model.githubRepoUser = parts[1]

--- a/lib/imdone-atom-github.coffee
+++ b/lib/imdone-atom-github.coffee
@@ -1,6 +1,10 @@
 Plugin = require './plugin'
 module.exports = ImdoneAtomGithub =
   config:
+    gitHubEnterpriseHost:
+      description: 'If you want to use imdone-atom with GitHub Enterprise, enter the hostname here.'
+      type: 'string'
+      default: ''
     defaultIssueMetaKey:
       description: 'The default meta key for github issues'
       type: 'string'

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -23,6 +23,16 @@ class Plugin extends Emitter
         metaData = task.getMetaData()
         metaData[@metaKey] if (@metaKey && metaData)
 
+    # GitHub Enterprise Support https://enterprise.github.com/help/articles/using-the-api
+    if atom.config.get("imdone-atom-github.gitHubEnterpriseHost")
+        @model.hostname = atom.config.get("imdone-atom-github.gitHubEnterpriseHost")
+        @model.resourceName = @model.hostname
+        @model.path = '/api/v3'
+    else
+        @model.hostname = 'api.github.com'
+        @model.resourceName = 'github.com'
+        @model.path = '/'
+
     @getIssueMetaKey()
     @githubService = new GithubService @model
     async.parallel [


### PR DESCRIPTION
I'd like to use imdone-atom-github together with a GitHub Enterprise instance. This PR makes some minor changes to allow for that, though there might be more elegant ways to achieve this.
